### PR TITLE
Add a standalone mode of operation in Executor.

### DIFF
--- a/import-automation/executor/README.md
+++ b/import-automation/executor/README.md
@@ -41,5 +41,9 @@ You could also use Cloud Scheduler to POST to the endpoints directly. For exampl
 
 ## Testing locally
 
-Run `python3 -m unittest`. See [test/test_integration](test/test_integration.py).
-First lines of the generated files would be printed.
+```
+./run_test.sh
+```
+
+See [test/test_integration](test/test_integration.py).  First lines of the
+generated files would be printed.

--- a/import-automation/executor/app/configs.py
+++ b/import-automation/executor/app/configs.py
@@ -2,17 +2,25 @@ import os
 
 from google.cloud import datastore
 
-PROJECT_ID = 'google.com:datcom-data'
 CONFIGS_NAMESPACE = 'configs'
 CONFIGS_KIND = 'config'
 MANIFEST_FILENAME = 'manifest.json'
 REQUIREMENTS_FILENAME = 'requirements.txt'
-REPO_OWNER_USERNAME = 'intrepiditee'
-GITHUB_AUTH_USERNAME = 'intrepiditee'
-REPO_NAME = 'data-demo'
-BUCKET_NAME = 'import-inputs'
 USER_SCRIPT_TIMEOUT = 600
 VENV_CREATE_TIMEOUT = 600
+GITHUB_AUTH_USERNAME = 'intrepiditee'
+
+
+#
+# Environment specific variables
+#
+def standalone():
+    return 'STANDALONE_MODE' in os.environ
+
+PROJECT_ID = 'datcom-cronjobs' if standalone() else 'google.com:datcom-data'
+REPO_OWNER_USERNAME = 'datacommonsorg' if standalone() else 'intrepiditee'
+REPO_NAME = 'data' if standalone() else 'data-demo'
+BUCKET_NAME = 'datcom-prod-imports' if standalone() else 'import-inputs'
 
 
 def _get_config(entity_id):

--- a/import-automation/executor/app/configs.py
+++ b/import-automation/executor/app/configs.py
@@ -30,12 +30,14 @@ def _get_config(entity_id):
 
 
 def get_dashboard_oauth_client_id():
+    if standalone(): return ''
     return _get_config('DASHBOARD_OAUTH_CLIENT_ID')
 
 
 def get_github_auth_access_token():
+    if standalone(): return ''
     return _get_config('GITHUB_AUTH_ACCESS_TOKEN')
 
 
 def production():
-    return 'EXECUTOR_PRODUCITON' in os.environ
+    return 'EXECUTOR_PRODUCTION' in os.environ

--- a/import-automation/executor/app/executor/executor.py
+++ b/import-automation/executor/app/executor/executor.py
@@ -77,8 +77,9 @@ def create_venv(requirements_path, venv_dir,
     with tempfile.NamedTemporaryFile(mode='w', suffix='.sh') as script:
         script.write(f'python3 -m virtualenv --verbose --clear {venv_dir}\n')
         script.write(f'. {venv_dir}/bin/activate\n')
-        script.write('python3 -m pip install --verbose --no-cache-dir '
-                     f'--requirement {requirements_path}\n')
+        if os.path.exists(requirements_path):
+          script.write('python3 -m pip install --verbose --no-cache-dir '
+                       f'--requirement {requirements_path}\n')
         script.flush()
 
         process = run_with_timeout(['bash', script.name], timeout)

--- a/import-automation/executor/app/executor/executor.py
+++ b/import-automation/executor/app/executor/executor.py
@@ -140,7 +140,14 @@ def _execute_imports_on_commit_helper(commit_sha, run_id):
                                                                import_name)
                 if import_all or absolute_name in import_targets or \
                         import_name in import_targets:
-                    import_one(dir_path, spec, run_id)
+                    import_name = spec['import_name']
+                    attempt_id = _init_attempt(
+                        run_id,
+                        import_name,
+                        os.path.join(dir_path, import_name),
+                        spec['provenance_url'],
+                        spec['provenance_description'])['attempt_id']
+                    import_one(dir_path, spec, run_id, attempt_id)
     return 'success'
 
 
@@ -214,7 +221,7 @@ def _execute_imports_on_update_helper(absolute_import_name, run_id):
         manifest = parse_manifest(manifest_path)
         for spec in manifest['import_specifications']:
             if import_name == 'all' or import_name == spec['import_name']:
-                import_one(dir_path, spec, run_id)
+                import_one(dir_path, spec, run_id, run_id)
 
     return 'success'
 
@@ -231,7 +238,7 @@ def execute_imports_on_update(absolute_import_name):
     Returns:
         A string describing the results of the imports.
     """
-    run_id = _init_run()['run_id']
+    run_id = absolute_import_name
     try:
         return _execute_imports_on_update_helper(absolute_import_name, run_id)
     except Exception as e:
@@ -319,22 +326,15 @@ def _import_one_helper(dir_path, import_spec, run_id, attempt_id):
     os.chdir(cwd)
 
 
-def import_one(dir_path, import_spec, run_id):
+def import_one(dir_path, import_spec, run_id, attempt_id):
     """Executes an import.
 
     Args:
         dir_path: Path to the direcotry containing the manifest as a string.
         import_spec: Specification of the import as a dict.
         run_id: ID of the system run the import belongs to.
+        attempt_id: Attempt ID.
     """
-    import_name = import_spec['import_name']
-    attempt_id = _init_attempt(
-        run_id,
-        import_name,
-        os.path.join(dir_path, import_name),
-        import_spec['provenance_url'],
-        import_spec['provenance_description'])['attempt_id']
-
     try:
         return _import_one_helper(dir_path, import_spec, run_id, attempt_id)
     except Exception as e:

--- a/import-automation/executor/app/executor/executor.py
+++ b/import-automation/executor/app/executor/executor.py
@@ -296,7 +296,7 @@ def _import_one_helper(dir_path, import_spec, run_id, attempt_id):
             process.check_returncode()
 
     time = utils.utctime()
-    path_prefix = f'{dir_path}:{import_spec["import_name"]}/{time}'
+    path_prefix = f'{dir_path}_{import_spec["import_name"]}/{time}'
     import_inputs = import_spec.get('import_inputs', [])
     for i, import_input in enumerate(import_inputs):
 
@@ -311,7 +311,7 @@ def _import_one_helper(dir_path, import_spec, run_id, attempt_id):
                                attempt_id=attempt_id)
             bucket_io.upload_file(
                 template_mcf,
-                f'{path_prefix}/{i}/{os.path.basename(template_mcf)}')
+                f'{path_prefix}/{os.path.basename(template_mcf)}')
 
         if cleaned_csv:
             with open(cleaned_csv) as f:

--- a/import-automation/executor/app/executor/executor.py
+++ b/import-automation/executor/app/executor/executor.py
@@ -206,10 +206,13 @@ def mark_import_attempt_failed(attempt_id):
 
 
 def _execute_imports_on_update_helper(absolute_import_name, run_id):
+    logging.info(absolute_import_name + ': BEGIN')
     github = github_api.GitHubRepoAPI()
     dashboard = dashboard_api.DashboardAPI()
     with tempfile.TemporaryDirectory() as tmpdir:
+        logging.info(absolute_import_name + ': downloading repo')
         repo_dirname = github.download_repo(tmpdir)
+        logging.info(absolute_import_name + ': downloaded repo ' + repo_dirname)
         cwd = os.path.join(tmpdir, repo_dirname)
         os.chdir(cwd)
 
@@ -219,10 +222,12 @@ def _execute_imports_on_update_helper(absolute_import_name, run_id):
             absolute_import_name)
         manifest_path = os.path.join(dir_path, configs.MANIFEST_FILENAME)
         manifest = parse_manifest(manifest_path)
+        logging.info(absolute_import_name + ': loaded manifest ' + manifest_path)
         for spec in manifest['import_specifications']:
             if import_name == 'all' or import_name == spec['import_name']:
                 import_one(dir_path, spec, run_id, run_id)
 
+    logging.info(absolute_import_name + ': END')
     return 'success'
 
 def execute_imports_on_update(absolute_import_name):

--- a/import-automation/executor/app/service/dashboard_api.py
+++ b/import-automation/executor/app/service/dashboard_api.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 
 from app import utils
 from app import configs
@@ -61,15 +62,15 @@ class DashboardAPI:
     def log(self, log):
         if configs.standalone():
           if log['level'] == LogLevel.CRITICAL:
-            logging.critical(message)
+            logging.critical(log['message'])
           elif log['level'] == LogLevel.ERROR:
-            logging.error(message)
+            logging.error(log['message'])
           elif log['level'] == LogLevel.WARNING:
-            logging.warning(message)
+            logging.warning(log['message'])
           elif log['level'] == LogLevel.INFO:
-            logging.info(message)
+            logging.info(log['message'])
           else:
-            logging.debug(message)
+            logging.debug(log['message'])
           return ''
 
         response = self.iap.post(_DASHBOARD_LOG_LIST, json=log).json()

--- a/import-automation/executor/app_standalone.yaml
+++ b/import-automation/executor/app_standalone.yaml
@@ -1,0 +1,10 @@
+runtime: python37
+entrypoint: gunicorn --timeout 600 -b :$PORT app.main:FLASK_APP
+env_variables:
+    STANDALONE_MODE: "True"
+    EXECUTOR_PRODUCTION: "True"
+    TMPDIR: "/tmp"
+basic_scaling:
+  max_instances: 1
+  idle_timeout: 10m
+instance_class: B4_1G

--- a/import-automation/executor/run_test.sh
+++ b/import-automation/executor/run_test.sh
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 -m venv .env
+source .env/bin/activate
+pip3 install -r requirements.txt
+python3 -m unittest -v


### PR DESCRIPTION
+ Incorporate a separate app_standalone.yaml.
+ Skip external API calls in dashboard_api in standalone mode.
+ Skip fetching creds for github/oauth in standalone mode.
+ Add a wrapper script for running tests.
+ Handle non-existent requirements.txt (for covid-tracking project)
+ Fix a typo in "EXECUTOR_PRODUCTION" that was preventing logging.
+ Skip index and ":" in output path names.