### PR TITLE
cron job scheduler

### DIFF
--- a/import-automation/executor/app/configs.py
+++ b/import-automation/executor/app/configs.py
@@ -75,7 +75,7 @@ class ExecutorConfig:
 
     def _get_config(self, entity_id):
         client = datastore.Client(project=self.gcp_project_id,
-                                  namespace=self.datastore_configs_kind)
+                                  namespace=self.datastore_configs_namespace)
         key = client.key(self.datastore_configs_kind, entity_id)
         return client.get(key)[entity_id]
 

--- a/import-automation/executor/app/executor/import_target.py
+++ b/import-automation/executor/app/executor/import_target.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Import targets specified in the commit message are of the form:
 1) <path to directory containing the manifest>:<import name>
@@ -26,7 +25,9 @@ Import targets specified in the commit message are of the form:
 """
 
 import re
-import typing
+from typing import List
+
+from app import utils
 
 _ALLOWED_PATH_CHARS = 'A-Za-z0-9-_/'
 _ALLOWED_RELATIVE_IMPORT_NAME_CHARS = 'A-Za-z0-9-_'
@@ -36,8 +37,8 @@ _ABSOLUTE_IMPORT_NAME_REGEX = r'[{}]+:[{}]+'.format(
     _ALLOWED_PATH_CHARS, _ALLOWED_RELATIVE_IMPORT_NAME_CHARS)
 _RELATIVE_IMPORT_NAME_REGEX = r'[{}]+'.format(
     _ALLOWED_RELATIVE_IMPORT_NAME_CHARS)
-_IMPORT_NAME_REGEX = r'{}|{}'.format(
-    _ABSOLUTE_IMPORT_NAME_REGEX, _RELATIVE_IMPORT_NAME_REGEX)
+_IMPORT_NAME_REGEX = r'{}|{}'.format(_ABSOLUTE_IMPORT_NAME_REGEX,
+                                     _RELATIVE_IMPORT_NAME_REGEX)
 
 
 def get_absolute_import_name(dir_path, import_name):
@@ -64,37 +65,40 @@ def filter_absolute_import_names(import_names):
     return list(name for name in import_names if is_absolute_import_name(name))
 
 
-def parse_commit_message_targets(commit_message: str) -> typing.List[str]:
-    """Parses the import targets from a commit message.
+def parse_commit_message_targets(commit_message: str,
+                                 tag: str = 'IMPORTS') -> List[str]:
+    """Parses the targets from a commit message.
 
-    Import targets are specified by including
-    IMPORTS=<comma separated list of import names> in the commit message.
+    Targets are specified by including a comma separated list of
+    import names in the commit message using a tag such as IMPORTS.
+    The format is <tag>=<import name>[,<import name>...]. E.g.,
+    'IMPORTS=scripts/us_fed:treasury,scripts/us_bls:cpi' and
+    'SCHEDULES=treasury'.
+
+    There cannot be spaces between import names or a comma at the
+    end of the list. E.g.,
+    'IMPORTS=scripts/us_fed:treasury, scripts/us_bls:cpi' and
+    'SCHEDULES=treasury,' are invalid.
 
     Args:
         commit_message: GitHub commit message as a string.
+        tag: The tag that starts the list, as a string.
 
     Returns:
         A list of import names each as a string.
     """
-    targets = set()
-    pattern = r'(?:IMPORTS=)([{},]+)'.format(
-        _ALLOWED_ABSOLUTE_IMPORT_NAME_CHARS)
-    target_lists = re.findall(pattern, commit_message)
-    for target_list in target_lists:
-        for target in target_list.split(','):
-            if not target or target.isspace():
-                continue
-            if is_absolute_import_name(target) or is_relative_import_name(target):
-                targets.add(target)
-            else:
-                raise ValueError(f'Import target {target} is not valid')
-    return list(targets)
+    targets = utils.parse_tag_list(commit_message, tag,
+                                   _ALLOWED_ABSOLUTE_IMPORT_NAME_CHARS)
+    for target in targets:
+        if (not target or target.isspace() or
+            (not is_absolute_import_name(target) and
+             not is_relative_import_name(target))):
+            raise ValueError(f'Target "{target}" is not valid')
+    return targets
 
 
-def import_targetted_by_commit(
-        import_dir: str,
-        import_name: str,
-        import_targets: typing.List[str]) -> bool:
+def import_targetted_by_commit(import_dir: str, import_name: str,
+                               import_targets: List[str]) -> bool:
     """Checks if an import should be executed upon the commit.
 
     See module docstring for the rules.
@@ -109,10 +113,7 @@ def import_targetted_by_commit(
     Returns:
         True, if the import should be executed. False, otherwise.
     """
-    absolute_name = get_absolute_import_name(
-        import_dir, import_name)
+    absolute_name = get_absolute_import_name(import_dir, import_name)
     absolute_all = get_absolute_import_name(import_dir, 'all')
-    return ('all' in import_targets or
-            absolute_name in import_targets or
-            import_name in import_targets or
-            absolute_all in import_targets)
+    return ('all' in import_targets or absolute_name in import_targets or
+            import_name in import_targets or absolute_all in import_targets)

--- a/import-automation/executor/app/executor/update_scheduler.py
+++ b/import-automation/executor/app/executor/update_scheduler.py
@@ -15,42 +15,157 @@
 Class for scheduling import updates using Google Cloud Scheduler.
 """
 
+import os
+import logging
 import json
-from typing import Dict
+import traceback
+import tempfile
+from typing import Dict, List
 
 from google.cloud import scheduler
+from google.protobuf import json_format
 
 from app import configs
+from app import utils
+from app.service import dashboard_api
+from app.service import github_api
+from app.executor import import_target
+from app.executor import import_executor
+from app.executor import validation
 
 
 class UpdateScheduler:
     """Class for scheduling import updates using Google Cloud Scheduler.
 
+    The scheduled jobs use the '/update' endpoint to update imports.
+
     Attributes:
         client: CloudSchedulerClient object for managing Google Cloud
             Scheduler jobs.
+        github: GitHubRepoAPI object for querying the GitHub API.
         config: ExecutorConfig object containing configurations for
             Cloud Scheduler.
+        dashboard: DashboardAPI for communicating with the
+            import progress dashboard. If not provided, the scheduler will not
+            communicate with the dashboard.
 
     Returns:
         Created job as a dict.
     """
 
-    def __init__(self, client: scheduler.CloudSchedulerClient,
-                 config: configs.ExecutorConfig):
+    def __init__(self,
+                 client: scheduler.CloudSchedulerClient,
+                 github: github_api.GitHubRepoAPI,
+                 config: configs.ExecutorConfig,
+                 dashboard: dashboard_api.DashboardAPI = None):
         self.client = client
+        self.github = github
         self.config = config
+        self.dashboard = dashboard
+
+    def schedule_on_commit(
+            self,
+            commit_sha: str,
+            repo_name: str = None,
+            branch_name: str = None,
+            pr_number: str = None) -> import_executor.ExecutionResult:
+        """Schedules periodic updates for imports specified in the commit
+        message of a GitHub commit.
+
+        Args:
+            commit_sha: ID of the commit as a string.
+            commit_sha: ID of the commit as a string.
+            repo_name: Name of the repository the commit is for as a string.
+            branch_name: Name of the branch the commit is for as a string.
+            pr_number: If the commit is a part of a pull request, the number of
+                the pull request as an int.
+
+        Returns:
+            ExecutionResult object whose imports_executed field contains the
+            jobs created each as a dict.
+        """
+        run_id = None
+        try:
+            if self.dashboard:
+                run_id = import_executor._init_run_helper(
+                    dashboard=self.dashboard,
+                    commit_sha=commit_sha,
+                    repo_name=repo_name,
+                    branch_name=branch_name,
+                    pr_number=pr_number)['run_id']
+        except Exception:
+            logging.exception(import_executor._SYSTEM_RUN_INIT_FAILED_MESSAGE)
+            return import_executor._create_system_run_init_failed_result(
+                traceback.format_exc())
+
+        return import_executor._run_and_handle_exception(
+            run_id, self.dashboard, self._schedule_on_commit_helper, commit_sha,
+            run_id)
+
+    def _schedule_on_commit_helper(
+            self, commit_sha: str,
+            run_id: str) -> import_executor.ExecutionResult:
+
+        commit_info = self.github.query_commit(commit_sha)
+        commit_message = commit_info['commit']['message']
+        manifest_dirs = self.github.find_dirs_in_commit_containing_file(
+            commit_sha, self.config.manifest_filename)
+        targets = import_target.parse_commit_message_targets(
+            commit_message, 'SCHEDULES')
+        if not targets:
+            message = ('No import target specified in commit message '
+                       f'({commit_message})')
+            return import_executor.ExecutionResult('pass', [], message)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_dir = self.github.download_repo(tmpdir, commit_sha)
+            repo_dir = os.path.join(tmpdir, repo_dir)
+            validation.are_import_targets_valid(targets, list(manifest_dirs),
+                                                repo_dir,
+                                                self.config.manifest_filename)
+            for target in import_target.filter_absolute_import_names(targets):
+                import_dir, _ = import_target.split_absolute_import_name(target)
+                manifest_dirs.add(import_dir)
+
+            scheduled = []
+            for import_dir in manifest_dirs:
+                absolute_import_dir = os.path.join(repo_dir, import_dir)
+                manifest_path = os.path.join(absolute_import_dir,
+                                             self.config.manifest_filename)
+                manifest = import_executor.parse_manifest(manifest_path)
+                validation.is_manifest_valid(manifest, repo_dir, import_dir)
+
+                for spec in manifest['import_specifications']:
+                    schedule = spec.get('cron_schedule')
+                    if not schedule:
+                        raise KeyError(
+                            f'cron_schedule not found in {manifest_path}')
+                    try:
+                        scheduled.append(
+                            self.create_schedule(
+                                import_target.get_absolute_import_name(
+                                    import_dir, spec['import_name']), schedule))
+                    except Exception:
+                        raise import_executor.ExecutionError(
+                            import_executor.ExecutionResult(
+                                'failed', scheduled, traceback.format_exc()))
+            return import_executor.ExecutionResult('succeeded', scheduled,
+                                                   'No issues')
 
     def create_schedule(self, absolute_import_name: str, schedule: str) -> Dict:
         """Schedules periodic updates for an import.
+
+        The body field of the app_engine_http_target field is converted from
+        bytes to dict.
 
         Example:
             The method call
                 create_schedule('scripts/us_fed:treasury', '* * * * *')
             schedules a cron job that updates the import every minute. The
-            name of the job is 'scripts_us_fed_treasury' and the description
-            is 'scripts/us_fed:treasury'. See _create_job_body for exact job
-            definition.
+            name of the job is 'scripts_us_fed_treasury_<current UTC time>',
+            e.g., 'scripts_us_fed_treasury_2020_07_24T16_27_22_609304_00_00',
+            and the description is 'scripts/us_fed:treasury'.
+            See _create_job_body for exact job definition.
 
         Attributes:
             absolute_import_name: Absolute import name of the import to be
@@ -65,12 +180,16 @@ class UpdateScheduler:
             Same exceptions as CloudSchedulerClient.create_job.
         """
         location_path = self.client.location_path(
-            _fix_project_id(self.config.gcp_project_id),
+            self.config.gcp_project_id,
             self.config.scheduler_location)
-        return dict(
-            self.client.create_job(
-                location_path,
-                self._create_job_body(absolute_import_name, schedule)))
+        job = self.client.create_job(
+            location_path,
+            self._create_job_body(absolute_import_name, schedule))
+        scheduled = json_format.MessageToDict(
+            job, preserving_proto_field_name=True)
+        scheduled['app_engine_http_target']['body'] = json.loads(
+            job.app_engine_http_target.body)
+        return scheduled
 
     def delete_schedule(self, absolute_import_name):
         """Deletes an update schedule for an import.
@@ -83,7 +202,7 @@ class UpdateScheduler:
             Same exceptions as CloudSchedulerClient.delete_job.
         """
         job_path = self.client.job_path(
-            _fix_project_id(self.config.gcp_project_id),
+            self.config.gcp_project_id,
             self.config.scheduler_location,
             _fix_absolute_import_name(absolute_import_name))
         self.client.delete_job(job_path)
@@ -103,11 +222,15 @@ class UpdateScheduler:
             The body of a Cloud Scheduler job as a dict that is ready to be used
             as an argument to CloudSchedulerClient.create_job.
         """
+        job_name = self.client.job_path(
+            self.config.gcp_project_id,
+            self.config.scheduler_location,
+            _fix_absolute_import_name(absolute_import_name))
         return {
-            'name': _fix_absolute_import_name(absolute_import_name),
+            'name': job_name,
             'description': absolute_import_name,
             'schedule': schedule,
-            'time_zone': 'utc',
+            'time_zone': 'Etc/UTC',
             'app_engine_http_target': {
                 'http_method':
                     'POST',
@@ -123,6 +246,10 @@ class UpdateScheduler:
                     json.dumps({
                         'absolute_import_name': absolute_import_name,
                         'configs': {
+                            'github_repo_name':
+                                self.config.github_repo_name,
+                            'github_repo_owner_username':
+                                self.config.github_repo_owner_username,
                             'github_auth_username':
                                 self.config.github_auth_username,
                             'github_auth_access_token':
@@ -151,13 +278,3 @@ def _fix_absolute_import_name(absolute_import_name: str) -> str:
     with underscores. This is for conforming to restrictions of Cloud Scheduler
     job names."""
     return absolute_import_name.replace('/', '_').replace(':', '_')
-
-
-def _fix_project_id(project_id: str) -> str:
-    """Converts Google Cloud project ID from the form <organization>:<project>
-    to <organization>/<project>."""
-    sep = ':'
-    if sep in project_id:
-        organization, project = project_id.split(sep)
-        return f'{organization}/{project}'
-    return project_id

--- a/import-automation/executor/app/executor/update_scheduler.py
+++ b/import-automation/executor/app/executor/update_scheduler.py
@@ -74,7 +74,6 @@ class UpdateScheduler:
 
         Args:
             commit_sha: ID of the commit as a string.
-            commit_sha: ID of the commit as a string.
             repo_name: Name of the repository the commit is for as a string.
             branch_name: Name of the branch the commit is for as a string.
             pr_number: If the commit is a part of a pull request, the number of
@@ -162,10 +161,9 @@ class UpdateScheduler:
             The method call
                 create_schedule('scripts/us_fed:treasury', '* * * * *')
             schedules a cron job that updates the import every minute. The
-            name of the job is 'scripts_us_fed_treasury_<current UTC time>',
-            e.g., 'scripts_us_fed_treasury_2020_07_24T16_27_22_609304_00_00',
-            and the description is 'scripts/us_fed:treasury'.
-            See _create_job_body for exact job definition.
+            name of the job is 'scripts_us_fed_treasury' and the description
+            is 'scripts/us_fed:treasury'. See _create_job_body for
+            exact job definition.
 
         Attributes:
             absolute_import_name: Absolute import name of the import to be

--- a/import-automation/executor/app/utils.py
+++ b/import-automation/executor/app/utils.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import re
 import datetime
+from typing import List
 
 import pytz
 import requests
@@ -26,7 +27,8 @@ def utctime():
 
 
 def pacific_time():
-    return datetime.datetime.now(pytz.timezone('America/Los_Angeles')).isoformat()
+    return datetime.datetime.now(
+        pytz.timezone('America/Los_Angeles')).isoformat()
 
 
 def list_to_str(a_list, sep=', '):
@@ -68,3 +70,29 @@ def download_file(url, dest_dir):
         with open(path, 'wb') as out:
             shutil.copyfileobj(response.raw, out)
         return path
+
+
+def parse_tag_list(message: str, tag: str, allowed_chars: str) -> List[str]:
+    """Parses a comma separated list following a tag.
+
+    Example:
+        The function call
+            parse_tag_list('abc IMPORTS=foo,bar abc', 'IMPORTS', 'a-z')
+        returns ['foo', 'bar'].
+
+    Args:
+        message: The message containing the list, as a string.
+        tag: The tag preceding the list, as a string.
+        allowed_chars: Valid characters in an element. This should be in regex
+            format, e.g. 'A-Za-z' and 'abc'.
+
+    Returns:
+        A list of elements each as a string.
+    """
+    targets = set()
+    pattern = r'(?:{}=)([{},]+)'.format(tag, allowed_chars)
+    target_lists = re.findall(pattern, message)
+    for target_list in target_lists:
+        for target in target_list.split(','):
+            targets.add(target)
+    return list(targets)

--- a/import-automation/executor/requirements.txt
+++ b/import-automation/executor/requirements.txt
@@ -1,4 +1,5 @@
 requests
+protobuf
 google-auth
 google-cloud-logging
 google-cloud-storage

--- a/import-automation/executor/test/test_import_executor.py
+++ b/import-automation/executor/test/test_import_executor.py
@@ -27,9 +27,12 @@ from app.executor import import_executor
 class ImportExecutorTest(unittest.TestCase):
 
     def test_clean_time(self):
-        self.assertEqual('2020_07_15T12_07_17_365264+00_00',
+        self.assertEqual('2020_07_15T12_07_17_365264_00_00',
                          import_executor._clean_time(
                              '2020-07-15T12:07:17.365264+00:00'))
+        self.assertEqual('2020_07_15T12_07_17_365264_07_00',
+                         import_executor._clean_time(
+                             '2020-07-15T12:07:17.365264-07:00'))
 
     def test_run_with_timeout(self):
         self.assertRaises(

--- a/import-automation/executor/test/test_import_target.py
+++ b/import-automation/executor/test/test_import_target.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Tests for import_target.py.
 """
@@ -31,36 +30,30 @@ class ImportTargetTest(unittest.TestCase):
         self.assertFalse(
             import_target.is_absolute_import_name(
                 'scripts/us_fed:treasury/data'))
-        self.assertFalse(
-            import_target.is_absolute_import_name(':treasury'))
+        self.assertFalse(import_target.is_absolute_import_name(':treasury'))
         self.assertFalse(
             import_target.is_absolute_import_name('scripts/us_fed:'))
         self.assertFalse(
             import_target.is_absolute_import_name('scripts/us_fed/treasury'))
         self.assertFalse(
             import_target.is_absolute_import_name(' scripts/us_fed:treasury'))
-        self.assertFalse(
-            import_target.is_absolute_import_name(''))
+        self.assertFalse(import_target.is_absolute_import_name(''))
 
     def test_parse_commit_message_targets(self):
-        self.assertEqual(
-            [], import_target.parse_commit_message_targets(''))
-        self.assertEqual(
-            [], import_target.parse_commit_message_targets('IMPORTS='))
+        self.assertEqual([], import_target.parse_commit_message_targets(''))
+        self.assertEqual([],
+                         import_target.parse_commit_message_targets('IMPORTS='))
         self.assertEqual(
             [], import_target.parse_commit_message_targets('imports=treasury'))
+        self.assertRaises(ValueError,
+                          import_target.parse_commit_message_targets,
+                          'IMPORTS=scripts/us_fed/treasury')
         self.assertRaises(
-            ValueError,
-            import_target.parse_commit_message_targets,
-            'IMPORTS=scripts/us_fed/treasury')
-        self.assertCountEqual(
-            ['scripts/us_fed:treasury'],
-            import_target.parse_commit_message_targets(
-                'abc IMPORTS=scripts/us_fed:treasury, scripts/us_bls:cpi'))
-        self.assertEqual(
-            ['scripts/us_fed:treasury'],
-            import_target.parse_commit_message_targets(
-                'IMPORTS=scripts/us_fed:treasury'))
+            ValueError, import_target.parse_commit_message_targets,
+            'abc IMPORTS=scripts/us_fed:treasury, scripts/us_bls:cpi')
+        self.assertEqual(['scripts/us_fed:treasury'],
+                         import_target.parse_commit_message_targets(
+                             'IMPORTS=scripts/us_fed:treasury'))
         self.assertEqual(
             ['scripts/us_fed:treasury'],
             import_target.parse_commit_message_targets(
@@ -75,18 +68,20 @@ class ImportTargetTest(unittest.TestCase):
             import_target.import_targetted_by_commit(
                 'scripts/us_fed', 'treasury', ['scripts/us_fed:treasury']))
         self.assertTrue(
-            import_target.import_targetted_by_commit(
-                'scripts/us_fed', 'treasury', ['all']))
+            import_target.import_targetted_by_commit('scripts/us_fed',
+                                                     'treasury', ['all']))
         self.assertTrue(
-            import_target.import_targetted_by_commit(
-                'scripts/us_fed', 'treasury', ['scripts/us_fed:all']))
+            import_target.import_targetted_by_commit('scripts/us_fed',
+                                                     'treasury',
+                                                     ['scripts/us_fed:all']))
         self.assertTrue(
             import_target.import_targetted_by_commit(
                 'scripts/us_fed', 'treasury',
                 ['scripts/us_fed:all', 'scripts/us_fed:else']))
         self.assertFalse(
-            import_target.import_targetted_by_commit(
-                'scripts/us_fed', 'treasury', []))
+            import_target.import_targetted_by_commit('scripts/us_fed',
+                                                     'treasury', []))
         self.assertFalse(
-            import_target.import_targetted_by_commit(
-                'scripts/us_fed', 'treasury', ['scripts/us_fed:else']))
+            import_target.import_targetted_by_commit('scripts/us_fed',
+                                                     'treasury',
+                                                     ['scripts/us_fed:else']))


### PR DESCRIPTION
This PR:
1. Adds an endpoint '/schedule' that takes a commit sha, parses the targets in the commit message, and schedules updates for those imports. The tag to use in the commit message is SCHEDULES.
2. Fixes a bug that _get_config was using a wrong Datastore namespace.

The scheduler duplicates a lot of code for the executor. I will do the refactoring in subsequent commits to keep this one small.

Tested locally and on GCP.

Thanks for reviewing.