### PR TITLE
Moving some logic for finding targets to functions

### DIFF
--- a/import-automation/executor/app/executor/import_executor.py
+++ b/import-automation/executor/app/executor/import_executor.py
@@ -163,11 +163,11 @@ class ImportExecutor:
         logging.info('%s: BEGIN', absolute_import_name)
         with tempfile.TemporaryDirectory() as tmpdir:
             logging.info('%s: downloading repo', absolute_import_name)
-            repo_dirname = self.github.download_repo(tmpdir)
+            repo_dir = self.github.download_repo(tmpdir)
             logging.info(absolute_import_name + ': downloaded repo ' +
-                         repo_dirname)
+                         repo_dir)
             if self.dashboard:
-                self.dashboard.info(f'Downloaded repo: {repo_dirname}',
+                self.dashboard.info(f'Downloaded repo: {repo_dir}',
                                     run_id=run_id)
 
             executed_imports = []
@@ -175,7 +175,7 @@ class ImportExecutor:
             # An example import_dir is 'scripts/us_fed/treasury'
             import_dir, import_name = import_target.split_absolute_import_name(
                 absolute_import_name)
-            absolute_import_dir = os.path.join(tmpdir, repo_dirname, import_dir)
+            absolute_import_dir = os.path.join(repo_dir, import_dir)
             manifest_path = os.path.join(absolute_import_dir,
                                          self.config.manifest_filename)
             manifest = parse_manifest(manifest_path)
@@ -223,7 +223,6 @@ class ImportExecutor:
             if self.dashboard:
                 self.dashboard.info(f'Downloaded repo: {repo_dir}',
                                     run_id=run_id)
-            repo_dir = os.path.join(tmpdir, repo_dir)
 
             imports_to_execute = import_target.find_imports_to_execute(
                 targets=targets,

--- a/import-automation/executor/app/executor/import_target.py
+++ b/import-automation/executor/app/executor/import_target.py
@@ -123,10 +123,8 @@ def is_import_targetted_by_commit(import_dir: str, import_name: str,
             import_name in import_targets or absolute_all in import_targets)
 
 
-def find_targets_in_commit(
-        commit_sha: str,
-        tag: str,
-        github: github_api.GitHubRepoAPI) -> List[str]:
+def find_targets_in_commit(commit_sha: str, tag: str,
+                           github: github_api.GitHubRepoAPI) -> List[str]:
     """Finds the targets specified in the commit message of a GitHub commit.
 
     Args:
@@ -139,16 +137,12 @@ def find_targets_in_commit(
     """
     commit_info = github.query_commit(commit_sha)
     commit_message = commit_info['commit']['message']
-    return parse_commit_message_targets(
-        commit_message, tag)
+    return parse_commit_message_targets(commit_message, tag)
 
 
-def find_imports_to_execute(
-    targets: List[str],
-    manifest_dirs: Set[str],
-    manifest_filename: str,
-    repo_dir: str
-) -> List[Tuple[str, Dict]]:
+def find_imports_to_execute(targets: List[str], manifest_dirs: Set[str],
+                            manifest_filename: str,
+                            repo_dir: str) -> List[Tuple[str, Dict]]:
     """Finds imports to execute on a GitHub commit.
 
     Args:
@@ -170,8 +164,8 @@ def find_imports_to_execute(
             are_import_targets_valid) or the manifest is not valid (see
             is_manifest_valid).
     """
-    validation.are_import_targets_valid(
-        targets, list(manifest_dirs), repo_dir, manifest_filename)
+    validation.are_import_targets_valid(targets, list(manifest_dirs), repo_dir,
+                                        manifest_filename)
 
     # Import targets specified in the commit message can be absolute,
     # e.g., 'scripts/us_fed/treasury:constant_maturity'.
@@ -192,8 +186,8 @@ def find_imports_to_execute(
         validation.is_manifest_valid(manifest, repo_dir, import_dir)
 
         for spec in manifest['import_specifications']:
-            if not is_import_targetted_by_commit(
-                    import_dir, spec['import_name'], targets):
+            if not is_import_targetted_by_commit(import_dir,
+                                                 spec['import_name'], targets):
                 continue
             imports_to_execute.append((import_dir, spec))
     return imports_to_execute

--- a/import-automation/executor/app/executor/import_target.py
+++ b/import-automation/executor/app/executor/import_target.py
@@ -148,7 +148,7 @@ def find_imports_to_execute(targets: List[str], manifest_dirs: Set[str],
     Args:
         targets: List of import targets specified by the commit message each as
             a string.
-        manifest_dirs: List of subdirectories of the repository touched by the
+        manifest_dirs: Set of subdirectories of the repository touched by the
             commit each as a string.
         manifest_filename: Filename of the manifest as a string.
         repo_dir: Absolute path to the repository as a string.

--- a/import-automation/executor/app/executor/import_target.py
+++ b/import-automation/executor/app/executor/import_target.py
@@ -24,10 +24,14 @@ Import targets specified in the commit message are of the form:
     All imports in directories touched by the commit are executed.
 """
 
+import os
 import re
-from typing import List
+from typing import List, Tuple, Dict, Set
 
 from app import utils
+from app.service import github_api
+from app.executor import validation
+from app.executor import import_executor
 
 _ALLOWED_PATH_CHARS = 'A-Za-z0-9-_/'
 _ALLOWED_RELATIVE_IMPORT_NAME_CHARS = 'A-Za-z0-9-_'
@@ -97,8 +101,8 @@ def parse_commit_message_targets(commit_message: str,
     return targets
 
 
-def import_targetted_by_commit(import_dir: str, import_name: str,
-                               import_targets: List[str]) -> bool:
+def is_import_targetted_by_commit(import_dir: str, import_name: str,
+                                  import_targets: List[str]) -> bool:
     """Checks if an import should be executed upon the commit.
 
     See module docstring for the rules.
@@ -117,3 +121,79 @@ def import_targetted_by_commit(import_dir: str, import_name: str,
     absolute_all = get_absolute_import_name(import_dir, 'all')
     return ('all' in import_targets or absolute_name in import_targets or
             import_name in import_targets or absolute_all in import_targets)
+
+
+def find_targets_in_commit(
+        commit_sha: str,
+        tag: str,
+        github: github_api.GitHubRepoAPI) -> List[str]:
+    """Finds the targets specified in the commit message of a GitHub commit.
+
+    Args:
+        commit_sha: ID of the commit as a string.
+        tag: The tag used to specify the list of targets, as a string.
+        github: GitHubRepoAPI object for querying the GitHub API.
+
+    Returns:
+        List of import names each as a string.
+    """
+    commit_info = github.query_commit(commit_sha)
+    commit_message = commit_info['commit']['message']
+    return parse_commit_message_targets(
+        commit_message, tag)
+
+
+def find_imports_to_execute(
+    targets: List[str],
+    manifest_dirs: Set[str],
+    manifest_filename: str,
+    repo_dir: str
+) -> List[Tuple[str, Dict]]:
+    """Finds imports to execute on a GitHub commit.
+
+    Args:
+        targets: List of import targets specified by the commit message each as
+            a string.
+        manifest_dirs: List of subdirectories of the repository touched by the
+            commit each as a string.
+        manifest_filename: Filename of the manifest as a string.
+        repo_dir: Absolute path to the repository as a string.
+
+    Returns:
+        List of tuples each consisting of 1) the path, as a string, to the
+        directory containing an import to execute, relative to the root
+        directory of the repository and 2) the import specification, as a dict,
+        of the import to execute.
+
+    Raises:
+        ValueError: The import targets are not valid (see
+            are_import_targets_valid) or the manifest is not valid (see
+            is_manifest_valid).
+    """
+    validation.are_import_targets_valid(
+        targets, list(manifest_dirs), repo_dir, manifest_filename)
+
+    # Import targets specified in the commit message can be absolute,
+    # e.g., 'scripts/us_fed/treasury:constant_maturity'.
+    # Add the directory components, e.g., 'scripts/us_fed/treasury',
+    # to manifest_dirs.
+    manifest_dirs = set(manifest_dirs)
+    for target in filter_absolute_import_names(targets):
+        import_dir, _ = split_absolute_import_name(target)
+        manifest_dirs.add(import_dir)
+    # At this point, manifest_dirs contains all the directories that
+    # will be looked at to look for imports.
+
+    imports_to_execute = []
+    for import_dir in manifest_dirs:
+        absolute_import_dir = os.path.join(repo_dir, import_dir)
+        manifest_path = os.path.join(absolute_import_dir, manifest_filename)
+        manifest = import_executor.parse_manifest(manifest_path)
+        validation.is_manifest_valid(manifest, repo_dir, import_dir)
+
+        for spec in manifest['import_specifications']:
+            if not is_import_targetted_by_commit(
+                    import_dir, spec['import_name'], targets):
+                continue
+            imports_to_execute.append((import_dir, spec))
+    return imports_to_execute

--- a/import-automation/executor/app/executor/update_scheduler.py
+++ b/import-automation/executor/app/executor/update_scheduler.py
@@ -105,8 +105,8 @@ class UpdateScheduler:
             self, commit_sha: str,
             run_id: str) -> import_executor.ExecutionResult:
 
-        targets = import_target.find_targets_in_commit(
-            commit_sha, 'SCHEDULES', self.github)
+        targets = import_target.find_targets_in_commit(commit_sha, 'SCHEDULES',
+                                                       self.github)
         if not targets:
             return import_executor.ExecutionResult(
                 'pass', [], 'No import target specified in commit message')
@@ -115,7 +115,6 @@ class UpdateScheduler:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_dir = self.github.download_repo(tmpdir, commit_sha)
-            repo_dir = os.path.join(tmpdir, repo_dir)
 
             imports_to_execute = import_target.find_imports_to_execute(
                 targets=targets,
@@ -127,8 +126,8 @@ class UpdateScheduler:
             for relative_dir, spec in imports_to_execute:
                 schedule = spec.get('cron_schedule')
                 if not schedule:
-                    manifest_path = os.path.join(
-                        relative_dir, self.config.manifest_filename)
+                    manifest_path = os.path.join(relative_dir,
+                                                 self.config.manifest_filename)
                     raise KeyError(
                         f'cron_schedule not found in {manifest_path}')
                 try:
@@ -138,8 +137,8 @@ class UpdateScheduler:
                         self.create_schedule(absolute_name, schedule))
                 except Exception:
                     raise import_executor.ExecutionError(
-                        import_executor.ExecutionResult(
-                            'failed', scheduled, traceback.format_exc()))
+                        import_executor.ExecutionResult('failed', scheduled,
+                                                        traceback.format_exc()))
             return import_executor.ExecutionResult('succeeded', scheduled,
                                                    'No issues')
 
@@ -170,13 +169,12 @@ class UpdateScheduler:
             Same exceptions as CloudSchedulerClient.create_job.
         """
         location_path = self.client.location_path(
-            self.config.gcp_project_id,
-            self.config.scheduler_location)
+            self.config.gcp_project_id, self.config.scheduler_location)
         job = self.client.create_job(
-            location_path,
-            self._create_job_body(absolute_import_name, schedule))
-        scheduled = json_format.MessageToDict(
-            job, preserving_proto_field_name=True)
+            location_path, self._create_job_body(absolute_import_name,
+                                                 schedule))
+        scheduled = json_format.MessageToDict(job,
+                                              preserving_proto_field_name=True)
         scheduled['app_engine_http_target']['body'] = json.loads(
             job.app_engine_http_target.body)
         return scheduled
@@ -192,8 +190,7 @@ class UpdateScheduler:
             Same exceptions as CloudSchedulerClient.delete_job.
         """
         job_path = self.client.job_path(
-            self.config.gcp_project_id,
-            self.config.scheduler_location,
+            self.config.gcp_project_id, self.config.scheduler_location,
             _fix_absolute_import_name(absolute_import_name))
         self.client.delete_job(job_path)
 
@@ -213,8 +210,7 @@ class UpdateScheduler:
             as an argument to CloudSchedulerClient.create_job.
         """
         job_name = self.client.job_path(
-            self.config.gcp_project_id,
-            self.config.scheduler_location,
+            self.config.gcp_project_id, self.config.scheduler_location,
             _fix_absolute_import_name(absolute_import_name))
         return {
             'name': job_name,

--- a/import-automation/executor/app/executor/update_scheduler.py
+++ b/import-automation/executor/app/executor/update_scheduler.py
@@ -105,49 +105,41 @@ class UpdateScheduler:
             self, commit_sha: str,
             run_id: str) -> import_executor.ExecutionResult:
 
-        commit_info = self.github.query_commit(commit_sha)
-        commit_message = commit_info['commit']['message']
+        targets = import_target.find_targets_in_commit(
+            commit_sha, 'SCHEDULES', self.github)
+        if not targets:
+            return import_executor.ExecutionResult(
+                'pass', [], 'No import target specified in commit message')
         manifest_dirs = self.github.find_dirs_in_commit_containing_file(
             commit_sha, self.config.manifest_filename)
-        targets = import_target.parse_commit_message_targets(
-            commit_message, 'SCHEDULES')
-        if not targets:
-            message = ('No import target specified in commit message '
-                       f'({commit_message})')
-            return import_executor.ExecutionResult('pass', [], message)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_dir = self.github.download_repo(tmpdir, commit_sha)
             repo_dir = os.path.join(tmpdir, repo_dir)
-            validation.are_import_targets_valid(targets, list(manifest_dirs),
-                                                repo_dir,
-                                                self.config.manifest_filename)
-            for target in import_target.filter_absolute_import_names(targets):
-                import_dir, _ = import_target.split_absolute_import_name(target)
-                manifest_dirs.add(import_dir)
+
+            imports_to_execute = import_target.find_imports_to_execute(
+                targets=targets,
+                manifest_dirs=manifest_dirs,
+                manifest_filename=self.config.manifest_filename,
+                repo_dir=repo_dir)
 
             scheduled = []
-            for import_dir in manifest_dirs:
-                absolute_import_dir = os.path.join(repo_dir, import_dir)
-                manifest_path = os.path.join(absolute_import_dir,
-                                             self.config.manifest_filename)
-                manifest = import_executor.parse_manifest(manifest_path)
-                validation.is_manifest_valid(manifest, repo_dir, import_dir)
-
-                for spec in manifest['import_specifications']:
-                    schedule = spec.get('cron_schedule')
-                    if not schedule:
-                        raise KeyError(
-                            f'cron_schedule not found in {manifest_path}')
-                    try:
-                        scheduled.append(
-                            self.create_schedule(
-                                import_target.get_absolute_import_name(
-                                    import_dir, spec['import_name']), schedule))
-                    except Exception:
-                        raise import_executor.ExecutionError(
-                            import_executor.ExecutionResult(
-                                'failed', scheduled, traceback.format_exc()))
+            for relative_dir, spec in imports_to_execute:
+                schedule = spec.get('cron_schedule')
+                if not schedule:
+                    manifest_path = os.path.join(
+                        relative_dir, self.config.manifest_filename)
+                    raise KeyError(
+                        f'cron_schedule not found in {manifest_path}')
+                try:
+                    absolute_name = import_target.get_absolute_import_name(
+                        relative_dir, spec['import_name'])
+                    scheduled.append(
+                        self.create_schedule(absolute_name, schedule))
+                except Exception:
+                    raise import_executor.ExecutionError(
+                        import_executor.ExecutionResult(
+                            'failed', scheduled, traceback.format_exc()))
             return import_executor.ExecutionResult('succeeded', scheduled,
                                                    'No issues')
 

--- a/import-automation/executor/app/service/github_api.py
+++ b/import-automation/executor/app/service/github_api.py
@@ -94,7 +94,7 @@ class GitHubRepoAPI:
             Assume the repository is named 'data-demo' owned by 'intrepiditee'.
             The method call
                 download_repo('download_dir', '12ef23231a')
-            returns 'intrepiditee-data-demo-12ef23231a'.
+            returns 'download_dir/intrepiditee-data-demo-12ef23231a'.
 
         Args:
             dest_dir: Directory to download the repository into as a string.
@@ -103,7 +103,7 @@ class GitHubRepoAPI:
                 is downloaded.
 
         Returns:
-            Name of a directory containing the downloaded repository,
+            Path to a directory containing the downloaded repository,
             as a string. The repository's contents are downloaded and copied
             into the same directory structure within the returned directory.
         """
@@ -131,7 +131,8 @@ class GitHubRepoAPI:
                     raise FileNotFoundError(
                         'Downloaded tar file does not contain the repository')
                 tar.extractall(dest_dir)
-                return _get_path_first_component(files[0])
+                return os.path.join(dest_dir,
+                                    _get_path_first_component(files[0]))
 
     def _build_content_query(self, commit_sha: str, path: str) -> str:
         return GITHUB_CONTENT_API.format_map({

--- a/import-automation/executor/test/test_github_api.py
+++ b/import-automation/executor/test/test_github_api.py
@@ -303,21 +303,22 @@ class GitHubAPITest(unittest.TestCase):
 
             with tempfile.TemporaryDirectory() as dir_path:
                 downloaded = self.github.download_repo(dir_path, 'commit-sha')
-                self.assertEqual('treasury_constant_maturity_rates', downloaded)
+                self.assertEqual(f'{dir_path}/treasury_constant_maturity_rates',
+                                 downloaded)
 
-                file = os.path.join(dir_path, downloaded,
+                file = os.path.join(downloaded,
                                     'treasury_constant_maturity_rates.csv')
                 assert test.utils.compare_lines(
                     'test/data/treasury_constant_maturity_rates.csv', file,
                     test_integration.NUM_LINES_TO_CHECK)
 
-                file = os.path.join(dir_path, downloaded,
+                file = os.path.join(downloaded,
                                     'treasury_constant_maturity_rates.mcf')
                 assert test.utils.compare_lines(
                     'test/data/treasury_constant_maturity_rates.mcf', file,
                     test_integration.NUM_LINES_TO_CHECK)
 
-                file = os.path.join(dir_path, downloaded,
+                file = os.path.join(downloaded,
                                     'treasury_constant_maturity_rates.tmcf')
                 assert test.utils.compare_lines(
                     'test/data/treasury_constant_maturity_rates.tmcf', file,

--- a/import-automation/executor/test/test_import_target.py
+++ b/import-automation/executor/test/test_import_target.py
@@ -63,25 +63,23 @@ class ImportTargetTest(unittest.TestCase):
             import_target.parse_commit_message_targets(
                 'ab IMPORTS=scripts/us_fed:treasury,scripts/us_bls:cpi,all cc'))
 
-    def test_import_targetted_by_commit(self):
+    def test_is_import_targetted_by_commit(self):
         self.assertTrue(
-            import_target.import_targetted_by_commit(
+            import_target.is_import_targetted_by_commit(
                 'scripts/us_fed', 'treasury', ['scripts/us_fed:treasury']))
         self.assertTrue(
-            import_target.import_targetted_by_commit('scripts/us_fed',
-                                                     'treasury', ['all']))
+            import_target.is_import_targetted_by_commit(
+                'scripts/us_fed', 'treasury', ['all']))
         self.assertTrue(
-            import_target.import_targetted_by_commit('scripts/us_fed',
-                                                     'treasury',
-                                                     ['scripts/us_fed:all']))
+            import_target.is_import_targetted_by_commit(
+                'scripts/us_fed', 'treasury', ['scripts/us_fed:all']))
         self.assertTrue(
-            import_target.import_targetted_by_commit(
+            import_target.is_import_targetted_by_commit(
                 'scripts/us_fed', 'treasury',
                 ['scripts/us_fed:all', 'scripts/us_fed:else']))
         self.assertFalse(
-            import_target.import_targetted_by_commit('scripts/us_fed',
-                                                     'treasury', []))
+            import_target.is_import_targetted_by_commit(
+                'scripts/us_fed', 'treasury', []))
         self.assertFalse(
-            import_target.import_targetted_by_commit('scripts/us_fed',
-                                                     'treasury',
-                                                     ['scripts/us_fed:else']))
+            import_target.is_import_targetted_by_commit(
+                'scripts/us_fed', 'treasury', ['scripts/us_fed:else']))


### PR DESCRIPTION
This PR:
1. moves some logic for finding targets to their own functions.
2. modified `github_api.GitHubRepoAPI.download_repo` to return a path instead of a name

Thanks for reviewing.
